### PR TITLE
New version: LazyArrays v0.12.1

### DIFF
--- a/L/LazyArrays/Versions.toml
+++ b/L/LazyArrays/Versions.toml
@@ -63,3 +63,6 @@ git-tree-sha1 = "631379228b52050c9c925d34db7d60b9073f2989"
 
 ["0.12.0"]
 git-tree-sha1 = "fbbf7e52929f74ed4f4d2fff4419f76807a443ef"
+
+["0.12.1"]
+git-tree-sha1 = "0e8448cc1774a8d067ce6dc576fcfa61f44adb2f"


### PR DESCRIPTION
UUID: 5078a376-72f3-5289-bfd5-ec5146d43c02
Repo: https://github.com/JuliaArrays/LazyArrays.jl.git
Tree: 0e8448cc1774a8d067ce6dc576fcfa61f44adb2f

Registrator tree SHA: f50e50c1d2a1b9694b1d5749fdb25fef2ca4c291